### PR TITLE
Add per-user devcontainer individualization via .env

### DIFF
--- a/.devcontainer/.env.template
+++ b/.devcontainer/.env.template
@@ -7,6 +7,21 @@ MISTRAL_API_KEY=""                      # FILLME
 GIT_AUTHOR_NAME=""                      # FILLME
 GIT_AUTHOR_EMAIL=""                     # FILLME
 
-# Ressource Limits
+# Resource Limits
 MEMORY_LIMIT=8G
 CPU_LIMIT=4
+
+# Tools
+INSTALL_CHROME=false                    # Browser MCP
+INSTALL_CLAUDE=false                    # Claude Code CLI
+INSTALL_CODEX=false                     # Codex CLI
+INSTALL_LATEX=false                     # Paper Writing
+INSTALL_UV=false                        # Python Package Manager
+
+# VSCode extensions
+EXT_COLAB=false                         # Google Colab Remote Kernel
+EXT_CONTAINERS=false                    # Docker Container Management
+EXT_DATAWRANGLER=false                  # Data Viewer
+EXT_JUPYTER=false                       # Jupyter Notebooks Local Kernel
+EXT_LATEX=false                         # LaTeX Editing And Compilation
+EXT_PYTHON=false                        # Python Language Support

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
+# https://github.com/devcontainers/images/tree/main/src/universal
 FROM mcr.microsoft.com/devcontainers/universal
 
 # Remove Yarn repo if present (fix upstream GPG issues)
@@ -10,20 +11,24 @@ RUN apt-get update && apt-get install -y \
   ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
-# Google Chrome (for chrome-devtools-mcp)
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | tee /etc/apt/trusted.gpg.d/google.asc >/dev/null \
+# Browser MCP
+ARG INSTALL_CHROME=false
+RUN if [ "$INSTALL_CHROME" = "true" ]; then \
+  wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | tee /etc/apt/trusted.gpg.d/google.asc >/dev/null \
   && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
   && apt-get update && apt-get install -y google-chrome-stable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*; fi
 
-# Latex suppport with common packages (paper writing)
-RUN apt-get update && apt-get install -y \
+# Paper Writing
+ARG INSTALL_LATEX=false
+RUN if [ "$INSTALL_LATEX" = "true" ]; then \
+  apt-get update && apt-get install -y \
   biber \
   latexmk \
   texlive-bibtex-extra \
   texlive-fonts-recommended \
   texlive-latex-extra \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*; fi
 
 # Firewall script (runs at container start)
 COPY firewall.py /usr/local/bin/firewall.py
@@ -37,9 +42,13 @@ USER codespace
 # TODO: Harden sudo rights for codespace user (currently NOPASSWD:ALL from base image)
 # sed -i 's/NOPASSWD:ALL/NOPASSWD: \/usr\/local\/share\/docker-init.sh, \/usr\/local\/share\/ssh-init.sh, \/usr\/local\/bin\/firewall.py/' /etc/sudoers.d/codespace
 
-# UV support (efficient package manager for Python)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# Python Package Manager
+ARG INSTALL_UV=false
+RUN if [ "$INSTALL_UV" = "true" ]; then curl -LsSf https://astral.sh/uv/install.sh | sh; fi
 # Claude Code CLI
-RUN curl -fsSL https://claude.ai/install.sh | bash
-# Codex
-RUN npm i -g @openai/codex
+ARG INSTALL_CLAUDE=true
+RUN if [ "$INSTALL_CLAUDE" = "true" ]; then curl -fsSL https://claude.ai/install.sh | bash; fi
+
+# Codex CLI
+ARG INSTALL_CODEX=false
+RUN if [ "$INSTALL_CODEX" = "true" ]; then npm i -g @openai/codex; fi

--- a/.devcontainer/allowed-domains.txt.template
+++ b/.devcontainer/allowed-domains.txt.template
@@ -4,6 +4,7 @@
 api.anthropic.com/32
 chatgpt.com/32
 auth.openai.com/32
+api.openai.com/32
 
 # Docker
 docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com/32
@@ -19,6 +20,7 @@ pypi.org/32
 # VS Code
 marketplace.visualstudio.com/32
 update.code.visualstudio.com/32
+*.gallerycdn.vsassets.io/24
 vscode.blob.core.windows.net/32
 
 # Custom

--- a/.devcontainer/commands/initialize.sh
+++ b/.devcontainer/commands/initialize.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Copy .env from template if it doesn't exist yet
+cp -n .devcontainer/.env.template .devcontainer/.env
+
+# Copy allowed-domains.txt from template if it doesn't exist yet
+cp -n .devcontainer/allowed-domains.txt.template .devcontainer/allowed-domains.txt

--- a/.devcontainer/commands/post-attach.sh
+++ b/.devcontainer/commands/post-attach.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Add VS Code remote CLI to PATH and IPC socket (not available by default in postAttachCommand)
+PATH="$PATH:$(find /vscode -name "remote-cli" -type d 2>/dev/null | head -1)"
+export VSCODE_IPC_HOOK_CLI=$(ls /tmp/vscode-ipc-*.sock 2>/dev/null | head -1)
+
+# Source user config
+if [ -f .devcontainer/.env ]; then
+    set -a
+    source .devcontainer/.env
+    set +a
+fi
+
+_ext() { code --install-extension "$1" || true; }
+
+[ "${EXT_COLAB:-false}"        = "true" ] && _ext "google.colab"
+[ "${EXT_CONTAINERS:-false}"   = "true" ] && _ext "ms-azuretools.vscode-containers"
+[ "${EXT_DATAWRANGLER:-false}" = "true" ] && _ext "ms-toolsai.datawrangler"
+[ "${EXT_JUPYTER:-false}"      = "true" ] && _ext "ms-toolsai.jupyter"
+[ "${EXT_LATEX:-false}"        = "true" ] && _ext "james-yu.latex-workshop"
+if [ "${EXT_PYTHON:-false}" = "true" ]; then
+    _ext "ms-python.python"
+    _ext "ms-python.mypy-type-checker"
+fi

--- a/.devcontainer/commands/post-start.sh
+++ b/.devcontainer/commands/post-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+sudo /usr/local/share/docker-init.sh
+sudo /usr/local/bin/firewall.py .devcontainer/allowed-domains.txt
+sudo service cron start

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,33 +14,19 @@
     // Which folder is the default inside the dev container
     "workspaceFolder": "/home/codespace/o3s",
 
-    // Intialize .env variables (happens on docker host, only if .env does not exist yet)
-    "initializeCommand": "cp -n .devcontainer/.env.template .devcontainer/.env && cp -n .devcontainer/allowed-domains.txt.template .devcontainer/allowed-domains.txt",
-    // Start docker daemon, set up firewall, and start cron for periodic IP refresh on every container start
-    "postStartCommand": "sudo /usr/local/share/docker-init.sh && sudo /usr/local/bin/firewall.py .devcontainer/allowed-domains.txt && sudo service cron start",
+    // Copy .env and allowed-domains.txt from templates if they don't exist yet
+    "initializeCommand": "bash .devcontainer/commands/initialize.sh",
+    // Start docker daemon, set up firewall, and start cron on every container start
+    "postStartCommand": "bash .devcontainer/commands/post-start.sh",
+    // Install extensions after VS Code attaches
+    "postAttachCommand": "bash .devcontainer/commands/post-attach.sh",
 
     // VSCode settings
     "customizations": {
         "vscode": {
             "settings": {
                 "remote.autoForwardPorts": false
-            },
-            "extensions": [
-                // Container Tools
-                "ms-azuretools.vscode-containers",
-                // Data viewer
-                "ms-toolsai.datawrangler",
-                // GitHub Pull Requests and Issues
-                "github.vscode-pull-request-github",
-                // Google Colab (Remote kernel with GPU)
-                "google.colab",
-                // Jupyter notebooks (Local kernel)
-                "ms-toolsai.jupyter",
-                // LaTeX editing and compilation
-                "james-yu.latex-workshop",
-                // Python
-                "ms-python.python"
-            ]
+            }
         }
     }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,11 +6,18 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        INSTALL_CHROME: ${INSTALL_CHROME:-false}
+        INSTALL_CLAUDE: ${INSTALL_CLAUDE:-false}
+        INSTALL_CODEX: ${INSTALL_CODEX:-false}
+        INSTALL_LATEX: ${INSTALL_LATEX:-false}
+        INSTALL_UV: ${INSTALL_UV:-false}
     image: o3s:latest
     container_name: o3s
-    environment:
+    environment: # If tools are missing they are silently ignored
       - CODEX_HOME=/home/codespace/config/codex
       - CLAUDE_CONFIG_DIR=/home/codespace/config/claude
+      - UV_PYTHON_INSTALL_DIR=/home/codespace/projects/.uv/python
       # Disable unneccesary claude network traffic
       - CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
       - DISABLE_GROWTHBOOK=1

--- a/.devcontainer/firewall.py
+++ b/.devcontainer/firewall.py
@@ -27,7 +27,7 @@ def to_network(ip: str, prefix: int) -> str:
 
 def resolve(domain: str) -> list[str]:
     try:
-        return list({r[4][0] for r in socket.getaddrinfo(domain, None, socket.AF_INET)})
+        return list({str(r[4][0]) for r in socket.getaddrinfo(domain, None, socket.AF_INET)})
     except socket.gaierror:
         print(f"WARNING: Failed to resolve {domain}, skipping")
         return []
@@ -39,12 +39,16 @@ def parse_allowlist(path: Path) -> list[tuple[str, int]]:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        if m := re.fullmatch(r"([A-Za-z0-9.-]+)/(\d{1,2})", line):
-            prefix = int(m.group(2))
+        if m := re.fullmatch(r"(\*\.)?([A-Za-z0-9.-]+)/(\d{1,2})", line):
+            wildcard = m.group(1)
+            domain   = m.group(2)
+            prefix   = int(m.group(3))
             if prefix > 32:
                 print(f"ERROR: Invalid prefix length in: {line}", file=sys.stderr)
                 sys.exit(1)
-            entries.append((m.group(1), prefix))
+            if wildcard:
+                domain = "probe." + domain
+            entries.append((domain, prefix))
         else:
             print(f"ERROR: Invalid entry (expected domain/prefix): {line}", file=sys.stderr)
             sys.exit(1)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 allowed-domains.txt
 o3s.code-workspace
 *.txt
+.certs/


### PR DESCRIPTION
- Tools (Chrome, LaTeX, Claude, Codex, uv) now optional via build ARGs driven by .env
- VS Code extensions selectable per-user via .env flags, installed via postAttachCommand
- Wildcard support in firewall.py for *.domain/prefix entries
- VS Code extension CDN added to allowed-domains template (*.gallerycdn.vsassets.io/24)
- Lifecycle scripts extracted to .devcontainer/commands/ (initialize, post-start, post-attach)