### PR TITLE
refactor(devcontainer): slim default features + pin upstream majors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,6 @@
     "service": "o3s",
 
     // Additional software layered onto the o3s image.
-    // Default build: docker + kubectl + claude. Uncomment the optional
-    // features below to enable them.
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:4": {
             "version": "stable",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,29 +10,32 @@
     "service": "o3s",
 
     // Additional software layered onto the o3s image.
+    // Default build: docker + kubectl + claude. Uncomment the optional
+    // features below to enable them.
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker": {
+        "ghcr.io/devcontainers/features/docker-in-docker:4": {
             "version": "stable",
             // Docker CE
             "moby": false
         },
-        "ghcr.io/devcontainers/features/kubectl-helm-minikube": {
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
             // kubectl
             "version": "stable",
             "helm": "latest",
             "minikube": "stable"
         },
-
         "ghcr.io/hansehart/devcontainer-features/claude-code:1": {
             "version": "stable",
-            "configDir": "/home/ubuntu/config/claude"
-        },
-        "ghcr.io/hansehart/devcontainer-features/headless-chrome:1": {
-            "version": "stable"
-        },
-        "ghcr.io/hansehart/devcontainer-features/latex:1": {
-            "version": "2025"
+            "configDir": "/home/ubuntu/config/claude",
+            "disableNonessentialTraffic": true
         }
+        // "ghcr.io/hansehart/devcontainer-features/headless-chrome:1": {
+        //     "version": "stable"
+        // },
+        // "ghcr.io/hansehart/devcontainer-features/latex:1": {
+        //     "version": "2025",
+        //     "scheme": "scheme-full"
+        // }
     },
 
     // Non-root user VS Code connects as


### PR DESCRIPTION
- Default build is docker + kubectl + claude; headless-chrome and latex are commented out as opt-in (uncomment to enable).
- Pin upstream features to their current majors (docker-in-docker:4, kubectl-helm-minikube:1), matching the :1-pinned local features. Guards against latest-major drift since the lockfile is gitignored.
- claude-code: set configDir and disableNonessentialTraffic; latex opt-in uses scheme-full.