### PR TITLE
refactor(devcontainer): migrate config volume to features, adopt stat…

### DIFF
--- a/.devcontainer/config/allowlist.txt.template
+++ b/.devcontainer/config/allowlist.txt.template
@@ -41,6 +41,7 @@ gitlab.com 22 443
 # AI providers
 api.anthropic.com 443
 chatgpt.com 443
+platform.claude.com 443
 auth.openai.com 443
 api.openai.com 443
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,28 +11,31 @@
 
     // Additional software layered onto the o3s image.
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:4": {
-            "version": "stable",
-            // Docker CE
-            "moby": false
-        },
-        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-            // kubectl
-            "version": "stable",
-            "helm": "latest",
-            "minikube": "stable"
-        },
         "ghcr.io/hansehart/devcontainer-features/claude-code:1": {
             "version": "stable",
-            "configDir": "/home/ubuntu/config/claude",
+            "stateDir": "/home/ubuntu/features/claude",
             "disableNonessentialTraffic": true
-        }
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:4": {
+            "version": "stable",
+            "moby": false // Docker CE
+        }// ,
         // "ghcr.io/hansehart/devcontainer-features/headless-chrome:1": {
         //     "version": "stable"
+        // },
+        // "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+        //     "version": "stable", // kubectl
+        //     "helm": "latest",
+        //     "minikube": "stable"
         // },
         // "ghcr.io/hansehart/devcontainer-features/latex:1": {
         //     "version": "2025",
         //     "scheme": "scheme-full"
+        // },
+        // "ghcr.io/hansehart/devcontainer-features/uv:1": {
+        //     "version": "latest",
+        //     "stateDir": "/home/ubuntu/features/uv",
+        //     "python": "3.13"
         // }
     },
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -54,8 +54,8 @@ services:
     volumes:
       # Host mount for dynamic changes
       - ../:/home/ubuntu/o3s
-      # Configuration for tools
-      - config:/home/ubuntu/config
+      # Persistent state for installed features
+      - features:/home/ubuntu/features
       # Volume mount for project to work with across sessions
       - projects:/home/ubuntu/projects
     # Limit ressource usage
@@ -103,5 +103,5 @@ networks:
     name: o3s-egress
 
 volumes:
-  config:
+  features:
   projects:


### PR DESCRIPTION
…eDir

Rename the config volume/mount to features (/home/ubuntu/features) for installed-feature state, switch claude-code from configDir to stateDir, slim defaults (comment out kubectl-helm-minikube, add commented uv block), and allowlist platform.claude.com.