### PR TITLE
ci(images): publish images on semver tags

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,10 +1,8 @@
 name: Publish devcontainer images
 on:
   push:
-    branches: [main]
-    paths:
-      - 'images/**'
-      - '.github/workflows/publish-images.yml'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 jobs:
@@ -41,7 +39,9 @@ jobs:
         with:
           images: ghcr.io/hansehart/${{ matrix.name }}
           tags: |
-            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/0.') }}
             type=sha
 
       # build each image and push it to GHCR with SBOM and provenance


### PR DESCRIPTION
Trigger the image publish workflow only on bare semver tags (X.Y.Z) instead of pushes to main, and emit semver image tags via docker/metadata-action: {{version}}, {{major}}.{{minor}}, and a {{major}} tag suppressed while in 0.x. `latest` is handled automatically by the default flavor for stable releases.