### PR TITLE
feat(gateway): egress deny self-test and RFC 5424 log format

### DIFF
--- a/.devcontainer/hooks/post-start.sh
+++ b/.devcontainer/hooks/post-start.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # Probe the first allow-listed host so the check tracks the configured allowlist
 PROBE_HOST="$(grep -vE '^[[:space:]]*#' .devcontainer/allowlist.txt | awk 'NF{print $1; exit}')"
 if curl -s --connect-timeout 5 -o /dev/null "https://$PROBE_HOST"; then
-  echo "[post-start] egress OK: $PROBE_HOST reachable through gateway"
+  echo "[post-start] INFO: egress OK, $PROBE_HOST reachable through gateway"
 else
-  echo "WARNING: $PROBE_HOST not reachable through gateway" >&2
+  echo "[post-start] WARNING: $PROBE_HOST not reachable through gateway" >&2
   set +e
   echo "---- egress diagnostics ----" >&2
   echo "routes:" >&2;      ip route show >&2
@@ -15,4 +15,12 @@ else
   echo "dns:" >&2;         getent hosts "$PROBE_HOST" >&2 || echo "  cannot resolve $PROBE_HOST" >&2
   echo "curl:" >&2;        curl -sS --connect-timeout 5 -o /dev/null "https://$PROBE_HOST" >&2
   echo "----------------------------" >&2
+fi
+
+DENY_HOST=1.1.1.1
+# deny check: a non-allow-listed public IP must stay blocked
+if curl -k -s --connect-timeout 3 -o /dev/null "https://$DENY_HOST"; then
+  echo "[post-start] WARNING: non-allow-listed $DENY_HOST:443 is reachable — egress policy is NOT enforced" >&2
+else
+  echo "[post-start] INFO: non-allow-listed egress blocked"
 fi

--- a/images/gateway/entrypoint.sh
+++ b/images/gateway/entrypoint.sh
@@ -10,8 +10,8 @@ UPSTREAM_DNS=127.0.0.11
 # domain stops being resolved. Static IP/CIDR seeds override this with timeout 0.
 IPSET_TIMEOUT=3600
 
-log() { echo "[gateway] $*"; }
-die() { echo "[gateway] $*" >&2; exit 1; }
+log() { echo "[gateway] INFO: $*"; }
+die() { echo "[gateway] ERROR: $*" >&2; exit 1; }
 
 # An address is static when it is an IPv4 host or CIDR; everything else is a domain.
 is_ipv4() { [[ "$1" =~ ^[0-9]+(\.[0-9]+){3}(/[0-9]+)?$ ]]; }

--- a/images/gateway/healthcheck.sh
+++ b/images/gateway/healthcheck.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+die() { echo "[healthcheck] ERROR: $*" >&2; exit 1; }
+
 # Probe the first allow-listed entry: connect to its address on its first port.
 first="$(grep -vhE '^[[:space:]]*(#|$)' /config/allowlist.txt | sed 's/#.*//' | grep -m1 .)" || true
 read -r ADDR PORT _ <<<"$first"
-[ -n "$ADDR" ] && [ -n "$PORT" ] || { echo "healthcheck: allowlist has no usable entry" >&2; exit 1; }
+[ -n "$ADDR" ] && [ -n "$PORT" ] || die "allowlist has no usable entry"
 
 # A domain resolves through dnsmasq (which also seeds the ipset); an IP is used as-is.
 case "$ADDR" in
@@ -12,7 +14,7 @@ case "$ADDR" in
                     | awk '/^Name/{f=1} f && /Address/ && $NF ~ /^[0-9]+(\.[0-9]+){3}$/ {print $NF; exit}')" || true ;;
   *)          IP="$ADDR" ;;
 esac
-[ -n "$IP" ] || { echo "healthcheck: dnsmasq did not resolve $ADDR" >&2; exit 1; }
+[ -n "$IP" ] || die "dnsmasq did not resolve $ADDR"
 
 nc -w3 "$IP" "$PORT" </dev/null >/dev/null 2>&1 \
-  || { echo "healthcheck: no egress - TCP $PORT to $ADDR ($IP) failed" >&2; exit 1; }
+  || die "no egress - TCP $PORT to $ADDR ($IP) failed"


### PR DESCRIPTION
- post-start: add a negative probe (a non-allow-listed public IP must stay blocked) alongside the existing positive reachability check, so the cage-side self-test proves the policy discriminates.
- unify logging to "[app] SEVERITY: message" across the gateway entrypoint, healthcheck, and post-start hook, using RFC 5424 severities (INFO/WARNING/ERROR).