### PR TITLE
chore(vscode): trim recommendations to notebook/data/AI extras

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,9 @@
 {
   "recommendations": [
-    "james-yu.latex-workshop",
-    "ms-azuretools.vscode-containers",
-    "ms-python.mypy-type-checker",
-    "ms-python.python",
+    "google.colab",
     "ms-toolsai.datawrangler",
-    "ms-toolsai.jupyter"
+    "ms-toolsai.jupyter",
+    "ms-toolsai.prompty",
+    "ms-toolsai.tensorboard"
   ]
 }


### PR DESCRIPTION
Move Python (python, mypy) and LaTeX (latex-workshop) into the uv/latex features where they now auto-install, and drop the redundant docker extension (already enforced by docker-in-docker). Add google.colab, ms-toolsai.prompty, and ms-toolsai.tensorboard as recommendations.