### PR TITLE
feat(devcontainer): add github-cli as an opt-in feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,10 @@
         "ghcr.io/devcontainers/features/docker-in-docker:4": {
             "version": "stable",
             "moby": false // Docker CE
-        }// ,
+        }//,
+        // "ghcr.io/devcontainers/features/github-cli:1": {
+        //     "version": "latest"
+        // },
         // "ghcr.io/hansehart/devcontainer-features/headless-chrome:1": {
         //     "version": "stable"
         // },


### PR DESCRIPTION
Add the GitHub CLI (gh) feature, pinned to :1 at version latest, commented out alongside the other opt-in features so users enable it when needed.