### PR TITLE
fix(allowlist): allow all VS Code extension CDN subdomains

### DIFF
--- a/.devcontainer/templates/allowlist.txt
+++ b/.devcontainer/templates/allowlist.txt
@@ -65,7 +65,8 @@ texlive.info 443
 # VS Code
 marketplace.visualstudio.com 443
 update.code.visualstudio.com 443
-ms-azuretools.gallerycdn.vsassets.io 443
+gallery.vsassets.io 443          
+gallerycdn.vsassets.io 443       
 vscode.blob.core.windows.net 443
 
 # Custom


### PR DESCRIPTION
  The egress gateway only permitted ms-azuretools.gallerycdn.vsassets.io, so
  extensions from other publishers (charliermarsh.ruff, ms-python.*, james-yu.*)
  failed to download with EAI_AGAIN. VS Code serves each publisher's manifest and
  VSIX from per-publisher hosts under gallerycdn.vsassets.io and gallery.vsassets.io.
  Allow both parent domains (dnsmasq covers subdomains) so all pinned extensions
  install, while staying tighter than a broad vsassets.io wildcard.