### PR TITLE
chore(devcontainer): friendlier hook logs and quieter CA generation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,10 +49,10 @@
         //     "stateDir": "/home/ubuntu/features/uv",
         //     "python": "3.13"
         // },
-        "ghcr.io/hansehart/devcontainer-features/sops:1": {
-            "version": "latest",
-            "stateDir": "/home/ubuntu/features/sops"
-        }
+        // "ghcr.io/hansehart/devcontainer-features/sops:1": {
+        //     "version": "latest",
+        //     "stateDir": "/home/ubuntu/features/sops"
+        // }
     },
     // Non-root user VS Code connects as
     "remoteUser": "ubuntu",

--- a/.devcontainer/hooks/initialize.sh
+++ b/.devcontainer/hooks/initialize.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Seed the editable config files from templates
-cp -n .devcontainer/templates/.env .devcontainer/.env
-cp -n .devcontainer/templates/config.toml .devcontainer/config.toml
-cp -n .devcontainer/templates/o3s.code-workspace .devcontainer/o3s.code-workspace
+log() { echo "[o3s] INFO: $*"; }
+
+# Seed each editable config file from its template if missing
+[ -f .devcontainer/.env ]               || cp .devcontainer/templates/.env .devcontainer/.env
+[ -f .devcontainer/config.toml ]        || cp .devcontainer/templates/config.toml .devcontainer/config.toml
+[ -f .devcontainer/o3s.code-workspace ] || cp .devcontainer/templates/o3s.code-workspace .devcontainer/o3s.code-workspace
 
 # Where this host's secrets live
 SECRETS_DIR="${O3S_SECRETS_DIR:-$HOME/.config/o3s}"
@@ -13,8 +15,11 @@ install -d -m 700 "$SECRETS_DIR"
 # This host's egress-proxy CA (idempotent)
 bash .devcontainer/mitm/gen-ca.sh
 
-# Seed the real-token file from its template (idempotent)
-[ -f "$SECRETS_DIR/secrets.env" ] || install -m 600 .devcontainer/templates/secrets.env "$SECRETS_DIR/secrets.env"
+# Seed the real-token file from its template
+if [ ! -f "$SECRETS_DIR/secrets.env" ]; then
+  install -m 600 .devcontainer/templates/secrets.env "$SECRETS_DIR/secrets.env"
+  log "add real tokens to $SECRETS_DIR/secrets.env"
+fi
 
 # Generate and apply the injection marker (idempotent)
 sed -i "s|__O3S_MARKER__|o3s-$(openssl rand -hex 32)|g" .devcontainer/.env

--- a/.devcontainer/hooks/post-start.sh
+++ b/.devcontainer/hooks/post-start.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 DENY_HOST=1.1.1.1
-# deny check: a non-allow-listed public IP must stay blocked
+# A non-allow-listed public IP must stay blocked
 if curl -k -s --connect-timeout 3 -o /dev/null "https://$DENY_HOST"; then
-  echo "[post-start] WARNING: non-allow-listed $DENY_HOST:443 is reachable — egress policy is NOT enforced" >&2
+  echo "[o3s] WARNING: egress policy not enforced ($DENY_HOST is reachable)" >&2
 else
-  echo "[post-start] INFO: non-allow-listed egress blocked"
+  echo "[o3s] INFO: egress firewall active (non-allowlisted traffic blocked)"
 fi

--- a/.devcontainer/mitm/gen-ca.sh
+++ b/.devcontainer/mitm/gen-ca.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+log() { echo "[o3s] INFO: $*"; }
+die() { echo "[o3s] ERROR: $*" >&2; exit 1; }
+
 # This host's per-machine CA
 SECRETS_DIR="${O3S_SECRETS_DIR:-$HOME/.config/o3s}"
 CA_PEM="$SECRETS_DIR/mitmproxy-ca.pem"
@@ -12,11 +15,15 @@ install -d -m 700 "$SECRETS_DIR"
 
 # Create the self-signed root CA once; mitmproxy signs per-host leaf certs with it.
 if [ ! -f "$CA_PEM" ]; then
-  openssl req -x509 -newkey rsa:4096 -nodes -days 3650 \
+  log "generating egress-proxy CA"
+  if ! out="$(openssl req -x509 -newkey rsa:4096 -nodes -days 3650 \
     -keyout "$CA_PEM" -out "$PUBLIC_CRT" \
     -subj "/O=o3s/CN=Egress Proxy CA" \
     -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
-    -addext "keyUsage=critical,keyCertSign,cRLSign"
+    -addext "keyUsage=critical,keyCertSign,cRLSign" 2>&1)"; then
+    echo "$out" >&2
+    die "could not generate CA"
+  fi
   cat "$PUBLIC_CRT" >> "$CA_PEM"   # mitmproxy reads one PEM: key then cert
 fi
 


### PR DESCRIPTION
- initialize.sh: per-file seeding guards, log the token reminder only when secrets.env is created
- gen-ca.sh: announce CA generation, suppress OpenSSL progress unless it fails
- post-start.sh: consistent [o3s] prefix and clearer egress messages
- devcontainer.json: disable the sops feature