### PR TITLE
ci(repo): exempt own rolling-tag images from digest pinning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,10 +27,12 @@
       "groupName": "Hansehart Devcontainer Features"
     },
     {
-      "description": "Bundle routine base-image digest refreshes into one pull request while keeping version bumps separate.",
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["pin", "digest"],
-      "groupName": "Docker Digests"
+      "description": "Images tracking a rolling tag do not need a digest pin.",
+      "matchPackageNames": [
+        "ghcr.io/hansehart/o3s-base",
+        "ghcr.io/hansehart/o3s-gateway"
+      ],
+      "pinDigests": false
     },
     {
       "description": "Label major updates so they get a deliberate review.",


### PR DESCRIPTION
Drop the digest-grouping rule and add a pinDigests exception for o3s-base and o3s-gateway, which track the rolling latest tag.