### PR TITLE
feat(base): install git in the image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -5,11 +5,12 @@ ENV LANG=C.UTF-8
 
 # Base packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      iproute2 \
       ca-certificates \
       curl \
-      ripgrep \
+      git \
+      iproute2 \
       openssh-client \
+      ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
 # Point runtimes with their own trust store at the system CA bundle


### PR DESCRIPTION
Every cage needs git for version control and editor integration, so install it in the base instead of relying on a feature to pull it in.