### PR TITLE
chore(devcontainer): track the latest release of each feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
             "disableNonessentialTraffic": true,
             "settingsJson": "{\\\"env\\\":{\\\"IS_DEMO\\\":\\\"1\\\"},\\\"attribution\\\":{\\\"commit\\\":\\\"\\\",\\\"pr\\\":\\\"\\\"}}",
             "stateDir": "/home/ubuntu/features/claude",
-            "version": "stable"
+            "version": "latest"
         },
         "ghcr.io/hansehart/devcontainer-features/docker-in-docker:1": {
             "daemonJson": "{\\\"dns\\\":[\\\"10.10.0.2\\\"]}",
@@ -33,12 +33,12 @@
         //     "version": "latest"
         // },
         // "ghcr.io/hansehart/devcontainer-features/headless-chrome:1": {
-        //     "version": "stable"
+        //     "version": "latest"
         // },
         // "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
         //     "helm": "latest",
-        //     "minikube": "stable",
-        //     "version": "stable" // kubectl
+        //     "minikube": "latest",
+        //     "version": "latest" // kubectl
         // },
         // "ghcr.io/hansehart/devcontainer-features/latex:1": {
         //     "scheme": "scheme-full",


### PR DESCRIPTION
The claude-code and headless-chrome features pinned the stable channel while every other entry tracked latest, and the kubectl-helm-minikube entry asked for a stable channel its options do not offer at all, where latest is the documented default.

The latex version and the uv python version stay pinned, being a choice of release rather than a channel.