### PR TITLE
fix(devcontainer): open nine syscalls instead of twenty-eight

### DIFF
--- a/.devcontainer/seccomp.json
+++ b/.devcontainer/seccomp.json
@@ -1,1149 +1,886 @@
 {
-	"defaultAction": "SCMP_ACT_ERRNO",
-	"defaultErrnoRet": 38,
-	"defaultErrno": "ENOSYS",
-	"archMap": [
-		{
-			"architecture": "SCMP_ARCH_X86_64",
-			"subArchitectures": [
-				"SCMP_ARCH_X86",
-				"SCMP_ARCH_X32"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_AARCH64",
-			"subArchitectures": [
-				"SCMP_ARCH_ARM"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_MIPS64",
-			"subArchitectures": [
-				"SCMP_ARCH_MIPS",
-				"SCMP_ARCH_MIPS64N32"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_MIPS64N32",
-			"subArchitectures": [
-				"SCMP_ARCH_MIPS",
-				"SCMP_ARCH_MIPS64"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_MIPSEL64",
-			"subArchitectures": [
-				"SCMP_ARCH_MIPSEL",
-				"SCMP_ARCH_MIPSEL64N32"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_MIPSEL64N32",
-			"subArchitectures": [
-				"SCMP_ARCH_MIPSEL",
-				"SCMP_ARCH_MIPSEL64"
-			]
-		},
-		{
-			"architecture": "SCMP_ARCH_S390X",
-			"subArchitectures": [
-				"SCMP_ARCH_S390"
-			]
-		}
-	],
-	"syscalls": [
-		{
-			"names": [
-				"bdflush",
-				"cachestat",
-				"io_pgetevents",
-				"io_pgetevents_time64",
-				"kexec_file_load",
-				"kexec_load",
-				"map_shadow_stack",
-				"migrate_pages",
-				"move_pages",
-				"nfsservctl",
-				"nice",
-				"oldfstat",
-				"oldlstat",
-				"oldolduname",
-				"oldstat",
-				"olduname",
-				"pciconfig_iobase",
-				"pciconfig_read",
-				"pciconfig_write",
-				"sgetmask",
-				"ssetmask",
-				"swapoff",
-				"swapon",
-				"syscall",
-				"sysfs",
-				"uselib",
-				"userfaultfd",
-				"ustat",
-				"vm86",
-				"vm86old",
-				"vmsplice"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"_llseek",
-				"_newselect",
-				"accept",
-				"accept4",
-				"access",
-				"adjtimex",
-				"alarm",
-				"bind",
-				"brk",
-				"capget",
-				"capset",
-				"chdir",
-				"chmod",
-				"chown",
-				"chown32",
-				"clock_adjtime",
-				"clock_adjtime64",
-				"clock_getres",
-				"clock_getres_time64",
-				"clock_gettime",
-				"clock_gettime64",
-				"clock_nanosleep",
-				"clock_nanosleep_time64",
-				"clone",
-				"clone3",
-				"close",
-				"close_range",
-				"connect",
-				"copy_file_range",
-				"creat",
-				"dup",
-				"dup2",
-				"dup3",
-				"epoll_create",
-				"epoll_create1",
-				"epoll_ctl",
-				"epoll_ctl_old",
-				"epoll_pwait",
-				"epoll_pwait2",
-				"epoll_wait",
-				"epoll_wait_old",
-				"eventfd",
-				"eventfd2",
-				"execve",
-				"execveat",
-				"exit",
-				"exit_group",
-				"faccessat",
-				"faccessat2",
-				"fadvise64",
-				"fadvise64_64",
-				"fallocate",
-				"fanotify_init",
-				"fanotify_mark",
-				"fchdir",
-				"fchmod",
-				"fchmodat",
-				"fchmodat2",
-				"fchown",
-				"fchown32",
-				"fchownat",
-				"fcntl",
-				"fcntl64",
-				"fdatasync",
-				"fgetxattr",
-				"flistxattr",
-				"flock",
-				"fork",
-				"fremovexattr",
-				"fsconfig",
-				"fsetxattr",
-				"fsmount",
-				"fsopen",
-				"fspick",
-				"fstat",
-				"fstat64",
-				"fstatat64",
-				"fstatfs",
-				"fstatfs64",
-				"fsync",
-				"ftruncate",
-				"ftruncate64",
-				"futex",
-				"futex_requeue",
-				"futex_time64",
-				"futex_wait",
-				"futex_waitv",
-				"futex_wake",
-				"futimesat",
-				"get_mempolicy",
-				"get_robust_list",
-				"get_thread_area",
-				"getcpu",
-				"getcwd",
-				"getdents",
-				"getdents64",
-				"getegid",
-				"getegid32",
-				"geteuid",
-				"geteuid32",
-				"getgid",
-				"getgid32",
-				"getgroups",
-				"getgroups32",
-				"getitimer",
-				"getpeername",
-				"getpgid",
-				"getpgrp",
-				"getpid",
-				"getppid",
-				"getpriority",
-				"getrandom",
-				"getresgid",
-				"getresgid32",
-				"getresuid",
-				"getresuid32",
-				"getrlimit",
-				"getrusage",
-				"getsid",
-				"getsockname",
-				"getsockopt",
-				"gettid",
-				"gettimeofday",
-				"getuid",
-				"getuid32",
-				"getxattr",
-				"inotify_add_watch",
-				"inotify_init",
-				"inotify_init1",
-				"inotify_rm_watch",
-				"io_cancel",
-				"io_destroy",
-				"io_getevents",
-				"io_setup",
-				"io_submit",
-				"ioctl",
-				"ioprio_get",
-				"ioprio_set",
-				"ipc",
-				"keyctl",
-				"kill",
-				"landlock_add_rule",
-				"landlock_create_ruleset",
-				"landlock_restrict_self",
-				"lchown",
-				"lchown32",
-				"lgetxattr",
-				"link",
-				"linkat",
-				"listen",
-				"listxattr",
-				"llistxattr",
-				"lremovexattr",
-				"lseek",
-				"lsetxattr",
-				"lstat",
-				"lstat64",
-				"madvise",
-				"mbind",
-				"membarrier",
-				"memfd_create",
-				"memfd_secret",
-				"mincore",
-				"mkdir",
-				"mkdirat",
-				"mknod",
-				"mknodat",
-				"mlock",
-				"mlock2",
-				"mlockall",
-				"mmap",
-				"mmap2",
-				"mount",
-				"mount_setattr",
-				"move_mount",
-				"mprotect",
-				"mq_getsetattr",
-				"mq_notify",
-				"mq_open",
-				"mq_timedreceive",
-				"mq_timedreceive_time64",
-				"mq_timedsend",
-				"mq_timedsend_time64",
-				"mq_unlink",
-				"mremap",
-				"msgctl",
-				"msgget",
-				"msgrcv",
-				"msgsnd",
-				"msync",
-				"munlock",
-				"munlockall",
-				"munmap",
-				"name_to_handle_at",
-				"nanosleep",
-				"newfstatat",
-				"open",
-				"open_tree",
-				"openat",
-				"openat2",
-				"pause",
-				"pidfd_getfd",
-				"pidfd_open",
-				"pidfd_send_signal",
-				"pipe",
-				"pipe2",
-				"pivot_root",
-				"pkey_alloc",
-				"pkey_free",
-				"pkey_mprotect",
-				"poll",
-				"ppoll",
-				"ppoll_time64",
-				"prctl",
-				"pread64",
-				"preadv",
-				"preadv2",
-				"prlimit64",
-				"process_mrelease",
-				"process_vm_readv",
-				"process_vm_writev",
-				"pselect6",
-				"pselect6_time64",
-				"ptrace",
-				"pwrite64",
-				"pwritev",
-				"pwritev2",
-				"read",
-				"readahead",
-				"readlink",
-				"readlinkat",
-				"readv",
-				"reboot",
-				"recv",
-				"recvfrom",
-				"recvmmsg",
-				"recvmmsg_time64",
-				"recvmsg",
-				"remap_file_pages",
-				"removexattr",
-				"rename",
-				"renameat",
-				"renameat2",
-				"restart_syscall",
-				"rmdir",
-				"rseq",
-				"rt_sigaction",
-				"rt_sigpending",
-				"rt_sigprocmask",
-				"rt_sigqueueinfo",
-				"rt_sigreturn",
-				"rt_sigsuspend",
-				"rt_sigtimedwait",
-				"rt_sigtimedwait_time64",
-				"rt_tgsigqueueinfo",
-				"sched_get_priority_max",
-				"sched_get_priority_min",
-				"sched_getaffinity",
-				"sched_getattr",
-				"sched_getparam",
-				"sched_getscheduler",
-				"sched_rr_get_interval",
-				"sched_rr_get_interval_time64",
-				"sched_setaffinity",
-				"sched_setattr",
-				"sched_setparam",
-				"sched_setscheduler",
-				"sched_yield",
-				"seccomp",
-				"select",
-				"semctl",
-				"semget",
-				"semop",
-				"semtimedop",
-				"semtimedop_time64",
-				"send",
-				"sendfile",
-				"sendfile64",
-				"sendmmsg",
-				"sendmsg",
-				"sendto",
-				"set_mempolicy",
-				"set_robust_list",
-				"set_thread_area",
-				"set_tid_address",
-				"setfsgid",
-				"setfsgid32",
-				"setfsuid",
-				"setfsuid32",
-				"setgid",
-				"setgid32",
-				"setgroups",
-				"setgroups32",
-				"setitimer",
-				"setns",
-				"setpgid",
-				"setpriority",
-				"setregid",
-				"setregid32",
-				"setresgid",
-				"setresgid32",
-				"setresuid",
-				"setresuid32",
-				"setreuid",
-				"setreuid32",
-				"setrlimit",
-				"setsid",
-				"setsockopt",
-				"setuid",
-				"setuid32",
-				"setxattr",
-				"shmat",
-				"shmctl",
-				"shmdt",
-				"shmget",
-				"shutdown",
-				"sigaltstack",
-				"signal",
-				"signalfd",
-				"signalfd4",
-				"sigprocmask",
-				"sigreturn",
-				"socketcall",
-				"socketpair",
-				"splice",
-				"stat",
-				"stat64",
-				"statfs",
-				"statfs64",
-				"statx",
-				"symlink",
-				"symlinkat",
-				"sync",
-				"sync_file_range",
-				"syncfs",
-				"sysinfo",
-				"syslog",
-				"tee",
-				"tgkill",
-				"time",
-				"timer_create",
-				"timer_delete",
-				"timer_getoverrun",
-				"timer_gettime",
-				"timer_gettime64",
-				"timer_settime",
-				"timer_settime64",
-				"timerfd_create",
-				"timerfd_gettime",
-				"timerfd_gettime64",
-				"timerfd_settime",
-				"timerfd_settime64",
-				"times",
-				"tkill",
-				"truncate",
-				"truncate64",
-				"ugetrlimit",
-				"umask",
-				"umount",
-				"umount2",
-				"uname",
-				"unlink",
-				"unlinkat",
-				"unshare",
-				"utime",
-				"utimensat",
-				"utimensat_time64",
-				"utimes",
-				"vfork",
-				"wait4",
-				"waitid",
-				"waitpid",
-				"write",
-				"writev"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"personality"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 0,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"personality"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 8,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"personality"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 131072,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"personality"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 131080,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"personality"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 4294967295,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"sync_file_range2",
-				"swapcontext"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"ppc64le"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"arm_fadvise64_64",
-				"arm_sync_file_range",
-				"breakpoint",
-				"cacheflush",
-				"set_tls",
-				"sync_file_range2"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"arm",
-					"arm64"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"arch_prctl"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"amd64",
-					"x32"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"modify_ldt"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"amd64",
-					"x32",
-					"x86"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"s390_pci_mmio_read",
-				"s390_pci_mmio_write",
-				"s390_runtime_instr"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"s390",
-					"s390x"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"riscv_flush_icache"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"arches": [
-					"riscv64"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"open_by_handle_at"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_DAC_READ_SEARCH"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"open_by_handle_at"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_DAC_READ_SEARCH"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"bpf",
-				"lookup_dcookie",
-				"perf_event_open",
-				"quotactl",
-				"quotactl_fd",
-				"setdomainname",
-				"sethostname",
-				"setns"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"lookup_dcookie",
-				"quotactl",
-				"quotactl_fd",
-				"setdomainname"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"sethostname",
-				"setns"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "o3s: nested container init calls these, and the cage holds no CAP_SYS_ADMIN, so the upstream rule would deny them",
-			"includes": {},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"chroot"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_CHROOT"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"chroot"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_CHROOT"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"delete_module",
-				"finit_module",
-				"init_module",
-				"query_module"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_MODULE"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"delete_module",
-				"finit_module",
-				"init_module",
-				"query_module"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_MODULE"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"acct"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_PACCT"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"acct"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_PACCT"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"kcmp",
-				"process_madvise"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_PTRACE"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"kcmp",
-				"process_madvise"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_PTRACE"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"ioperm",
-				"iopl"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_RAWIO"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"ioperm",
-				"iopl"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_RAWIO"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"clock_settime",
-				"clock_settime64",
-				"settimeofday",
-				"stime"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_TIME"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"clock_settime",
-				"clock_settime64",
-				"settimeofday",
-				"stime"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_TIME"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"vhangup"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_SYS_TTY_CONFIG"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"vhangup"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_TTY_CONFIG"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [
-				{
-					"index": 0,
-					"value": 40,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [
-				{
-					"index": 0,
-					"value": 16,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				},
-				{
-					"index": 2,
-					"value": 9,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_AUDIT_WRITE"
-				]
-			},
-			"errnoRet": 22,
-			"errno": "EINVAL"
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 16,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_EQ"
-				},
-				{
-					"index": 2,
-					"value": 9,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_NE"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_AUDIT_WRITE"
-				]
-			}
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 16,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_NE"
-				}
-			],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_AUDIT_WRITE"
-				]
-			}
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [
-				{
-					"index": 0,
-					"value": 40,
-					"valueTwo": 0,
-					"op": "SCMP_CMP_NE"
-				}
-			],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_AUDIT_WRITE"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"bpf"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN",
-					"CAP_BPF"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"bpf"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_BPF"
-				]
-			},
-			"excludes": {}
-		},
-		{
-			"names": [
-				"perf_event_open"
-			],
-			"action": "SCMP_ACT_ERRNO",
-			"args": [],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_SYS_ADMIN",
-					"CAP_PERFMON"
-				]
-			},
-			"errnoRet": 1,
-			"errno": "EPERM"
-		},
-		{
-			"names": [
-				"perf_event_open"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": [],
-			"comment": "",
-			"includes": {
-				"caps": [
-					"CAP_PERFMON"
-				]
-			},
-			"excludes": {}
-		}
-	]
+    "defaultAction": "SCMP_ACT_ERRNO",
+    "defaultErrnoRet": 1,
+    "archMap": [
+        {
+            "architecture": "SCMP_ARCH_X86_64",
+            "subArchitectures": [
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_AARCH64",
+            "subArchitectures": [
+                "SCMP_ARCH_ARM"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPS64",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPS",
+                "SCMP_ARCH_MIPS64N32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPS64N32",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPS",
+                "SCMP_ARCH_MIPS64"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPSEL64",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPSEL",
+                "SCMP_ARCH_MIPSEL64N32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_MIPSEL64N32",
+            "subArchitectures": [
+                "SCMP_ARCH_MIPSEL",
+                "SCMP_ARCH_MIPSEL64"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_S390X",
+            "subArchitectures": [
+                "SCMP_ARCH_S390"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_RISCV64",
+            "subArchitectures": null
+        },
+        {
+            "architecture": "SCMP_ARCH_LOONGARCH64",
+            "subArchitectures": null
+        }
+    ],
+    "syscalls": [
+        {
+            "names": [
+                "accept",
+                "accept4",
+                "access",
+                "adjtimex",
+                "alarm",
+                "bind",
+                "brk",
+                "cachestat",
+                "capget",
+                "capset",
+                "chdir",
+                "chmod",
+                "chown",
+                "chown32",
+                "clock_adjtime",
+                "clock_adjtime64",
+                "clock_getres",
+                "clock_getres_time64",
+                "clock_gettime",
+                "clock_gettime64",
+                "clock_nanosleep",
+                "clock_nanosleep_time64",
+                "close",
+                "close_range",
+                "connect",
+                "copy_file_range",
+                "creat",
+                "dup",
+                "dup2",
+                "dup3",
+                "epoll_create",
+                "epoll_create1",
+                "epoll_ctl",
+                "epoll_ctl_old",
+                "epoll_pwait",
+                "epoll_pwait2",
+                "epoll_wait",
+                "epoll_wait_old",
+                "eventfd",
+                "eventfd2",
+                "execve",
+                "execveat",
+                "exit",
+                "exit_group",
+                "faccessat",
+                "faccessat2",
+                "fadvise64",
+                "fadvise64_64",
+                "fallocate",
+                "fanotify_mark",
+                "fchdir",
+                "fchmod",
+                "fchmodat",
+                "fchmodat2",
+                "fchown",
+                "fchown32",
+                "fchownat",
+                "fcntl",
+                "fcntl64",
+                "fdatasync",
+                "fgetxattr",
+                "flistxattr",
+                "flock",
+                "fork",
+                "fremovexattr",
+                "fsetxattr",
+                "fstat",
+                "fstat64",
+                "fstatat64",
+                "fstatfs",
+                "fstatfs64",
+                "fsync",
+                "ftruncate",
+                "ftruncate64",
+                "futex",
+                "futex_requeue",
+                "futex_time64",
+                "futex_wait",
+                "futex_waitv",
+                "futex_wake",
+                "futimesat",
+                "getcpu",
+                "getcwd",
+                "getdents",
+                "getdents64",
+                "getegid",
+                "getegid32",
+                "geteuid",
+                "geteuid32",
+                "getgid",
+                "getgid32",
+                "getgroups",
+                "getgroups32",
+                "getitimer",
+                "getpeername",
+                "getpgid",
+                "getpgrp",
+                "getpid",
+                "getppid",
+                "getpriority",
+                "getrandom",
+                "getresgid",
+                "getresgid32",
+                "getresuid",
+                "getresuid32",
+                "getrlimit",
+                "get_robust_list",
+                "getrusage",
+                "getsid",
+                "getsockname",
+                "getsockopt",
+                "get_thread_area",
+                "gettid",
+                "gettimeofday",
+                "getuid",
+                "getuid32",
+                "getxattr",
+                "getxattrat",
+                "inotify_add_watch",
+                "inotify_init",
+                "inotify_init1",
+                "inotify_rm_watch",
+                "io_cancel",
+                "ioctl",
+                "io_destroy",
+                "io_getevents",
+                "io_pgetevents",
+                "io_pgetevents_time64",
+                "ioprio_get",
+                "ioprio_set",
+                "io_setup",
+                "io_submit",
+                "ipc",
+                "kill",
+                "landlock_add_rule",
+                "landlock_create_ruleset",
+                "landlock_restrict_self",
+                "lchown",
+                "lchown32",
+                "lgetxattr",
+                "link",
+                "linkat",
+                "listen",
+                "listmount",
+                "listxattr",
+                "listxattrat",
+                "llistxattr",
+                "_llseek",
+                "lremovexattr",
+                "lseek",
+                "lsetxattr",
+                "lstat",
+                "lstat64",
+                "madvise",
+                "map_shadow_stack",
+                "membarrier",
+                "memfd_create",
+                "memfd_secret",
+                "mincore",
+                "mkdir",
+                "mkdirat",
+                "mknod",
+                "mknodat",
+                "mlock",
+                "mlock2",
+                "mlockall",
+                "mmap",
+                "mmap2",
+                "mprotect",
+                "mq_getsetattr",
+                "mq_notify",
+                "mq_open",
+                "mq_timedreceive",
+                "mq_timedreceive_time64",
+                "mq_timedsend",
+                "mq_timedsend_time64",
+                "mq_unlink",
+                "mremap",
+                "mseal",
+                "msgctl",
+                "msgget",
+                "msgrcv",
+                "msgsnd",
+                "msync",
+                "munlock",
+                "munlockall",
+                "munmap",
+                "name_to_handle_at",
+                "nanosleep",
+                "newfstatat",
+                "_newselect",
+                "open",
+                "openat",
+                "openat2",
+                "pause",
+                "pidfd_open",
+                "pidfd_send_signal",
+                "pipe",
+                "pipe2",
+                "pkey_alloc",
+                "pkey_free",
+                "pkey_mprotect",
+                "poll",
+                "ppoll",
+                "ppoll_time64",
+                "prctl",
+                "pread64",
+                "preadv",
+                "preadv2",
+                "prlimit64",
+                "process_mrelease",
+                "pselect6",
+                "pselect6_time64",
+                "pwrite64",
+                "pwritev",
+                "pwritev2",
+                "read",
+                "readahead",
+                "readlink",
+                "readlinkat",
+                "readv",
+                "recv",
+                "recvfrom",
+                "recvmmsg",
+                "recvmmsg_time64",
+                "recvmsg",
+                "remap_file_pages",
+                "removexattr",
+                "removexattrat",
+                "rename",
+                "renameat",
+                "renameat2",
+                "restart_syscall",
+                "riscv_hwprobe",
+                "rmdir",
+                "rseq",
+                "rt_sigaction",
+                "rt_sigpending",
+                "rt_sigprocmask",
+                "rt_sigqueueinfo",
+                "rt_sigreturn",
+                "rt_sigsuspend",
+                "rt_sigtimedwait",
+                "rt_sigtimedwait_time64",
+                "rt_tgsigqueueinfo",
+                "sched_getaffinity",
+                "sched_getattr",
+                "sched_getparam",
+                "sched_get_priority_max",
+                "sched_get_priority_min",
+                "sched_getscheduler",
+                "sched_rr_get_interval",
+                "sched_rr_get_interval_time64",
+                "sched_setaffinity",
+                "sched_setattr",
+                "sched_setparam",
+                "sched_setscheduler",
+                "sched_yield",
+                "seccomp",
+                "select",
+                "semctl",
+                "semget",
+                "semop",
+                "semtimedop",
+                "semtimedop_time64",
+                "send",
+                "sendfile",
+                "sendfile64",
+                "sendmmsg",
+                "sendmsg",
+                "sendto",
+                "setfsgid",
+                "setfsgid32",
+                "setfsuid",
+                "setfsuid32",
+                "setgid",
+                "setgid32",
+                "setgroups",
+                "setgroups32",
+                "setitimer",
+                "setpgid",
+                "setpriority",
+                "setregid",
+                "setregid32",
+                "setresgid",
+                "setresgid32",
+                "setresuid",
+                "setresuid32",
+                "setreuid",
+                "setreuid32",
+                "setrlimit",
+                "set_robust_list",
+                "setsid",
+                "setsockopt",
+                "set_thread_area",
+                "set_tid_address",
+                "setuid",
+                "setuid32",
+                "setxattr",
+                "setxattrat",
+                "shmat",
+                "shmctl",
+                "shmdt",
+                "shmget",
+                "shutdown",
+                "sigaltstack",
+                "signalfd",
+                "signalfd4",
+                "sigprocmask",
+                "sigreturn",
+                "socketcall",
+                "socketpair",
+                "splice",
+                "stat",
+                "stat64",
+                "statfs",
+                "statfs64",
+                "statmount",
+                "statx",
+                "symlink",
+                "symlinkat",
+                "sync",
+                "sync_file_range",
+                "syncfs",
+                "sysinfo",
+                "tee",
+                "tgkill",
+                "time",
+                "timer_create",
+                "timer_delete",
+                "timer_getoverrun",
+                "timer_gettime",
+                "timer_gettime64",
+                "timer_settime",
+                "timer_settime64",
+                "timerfd_create",
+                "timerfd_gettime",
+                "timerfd_gettime64",
+                "timerfd_settime",
+                "timerfd_settime64",
+                "times",
+                "tkill",
+                "truncate",
+                "truncate64",
+                "ugetrlimit",
+                "umask",
+                "uname",
+                "unlink",
+                "unlinkat",
+                "uretprobe",
+                "utime",
+                "utimensat",
+                "utimensat_time64",
+                "utimes",
+                "vfork",
+                "vmsplice",
+                "wait4",
+                "waitid",
+                "waitpid",
+                "write",
+                "writev"
+            ],
+            "action": "SCMP_ACT_ALLOW"
+        },
+        {
+            "names": [
+                "process_vm_readv",
+                "process_vm_writev",
+                "ptrace"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "minKernel": "4.8"
+            }
+        },
+        {
+            "names": [
+                "socket"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 38,
+                    "op": "SCMP_CMP_LT"
+                }
+            ]
+        },
+        {
+            "names": [
+                "socket"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 39,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "socket"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 40,
+                    "op": "SCMP_CMP_GT"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 0,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 8,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 131072,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 131080,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "personality"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 4294967295,
+                    "op": "SCMP_CMP_EQ"
+                }
+            ]
+        },
+        {
+            "names": [
+                "sync_file_range2",
+                "swapcontext"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "ppc64le"
+                ]
+            }
+        },
+        {
+            "names": [
+                "arm_fadvise64_64",
+                "arm_sync_file_range",
+                "sync_file_range2",
+                "breakpoint",
+                "cacheflush",
+                "set_tls"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "arm",
+                    "arm64"
+                ]
+            }
+        },
+        {
+            "names": [
+                "arch_prctl"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "amd64",
+                    "x32"
+                ]
+            }
+        },
+        {
+            "names": [
+                "modify_ldt"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "amd64",
+                    "x32",
+                    "x86"
+                ]
+            }
+        },
+        {
+            "names": [
+                "s390_pci_mmio_read",
+                "s390_pci_mmio_write",
+                "s390_runtime_instr"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            }
+        },
+        {
+            "names": [
+                "riscv_flush_icache"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "arches": [
+                    "riscv64"
+                ]
+            }
+        },
+        {
+            "names": [
+                "open_by_handle_at"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_DAC_READ_SEARCH"
+                ]
+            }
+        },
+        {
+            "names": [
+                "bpf",
+                "fanotify_init",
+                "fsconfig",
+                "fsmount",
+                "fsopen",
+                "fspick",
+                "lookup_dcookie",
+                "lsm_get_self_attr",
+                "lsm_list_modules",
+                "lsm_set_self_attr",
+                "mount_setattr",
+                "move_mount",
+                "open_tree",
+                "perf_event_open",
+                "quotactl",
+                "quotactl_fd",
+                "setdomainname",
+                "syslog",
+                "umount"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 0,
+                    "value": 2114060288,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ],
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ],
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [
+                {
+                    "index": 1,
+                    "value": 2114060288,
+                    "op": "SCMP_CMP_MASKED_EQ"
+                }
+            ],
+            "comment": "s390 parameter ordering for clone is different",
+            "includes": {
+                "arches": [
+                    "s390",
+                    "s390x"
+                ]
+            },
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone3"
+            ],
+            "action": "SCMP_ACT_ERRNO",
+            "errnoRet": 38,
+            "excludes": {
+                "caps": [
+                    "CAP_SYS_ADMIN"
+                ]
+            }
+        },
+        {
+            "names": [
+                "reboot"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_BOOT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "chroot"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_CHROOT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "delete_module",
+                "init_module",
+                "finit_module"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_MODULE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "acct"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_PACCT"
+                ]
+            }
+        },
+        {
+            "names": [
+                "kcmp",
+                "pidfd_getfd",
+                "process_madvise",
+                "process_vm_readv",
+                "process_vm_writev",
+                "ptrace"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_PTRACE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "iopl",
+                "ioperm"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_RAWIO"
+                ]
+            }
+        },
+        {
+            "names": [
+                "settimeofday",
+                "stime",
+                "clock_settime",
+                "clock_settime64"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_TIME"
+                ]
+            }
+        },
+        {
+            "names": [
+                "vhangup"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_TTY_CONFIG"
+                ]
+            }
+        },
+        {
+            "names": [
+                "get_mempolicy",
+                "mbind",
+                "set_mempolicy",
+                "set_mempolicy_home_node"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYS_NICE"
+                ]
+            }
+        },
+        {
+            "names": [
+                "syslog"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_SYSLOG"
+                ]
+            }
+        },
+        {
+            "names": [
+                "bpf"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_BPF"
+                ]
+            }
+        },
+        {
+            "names": [
+                "perf_event_open"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "includes": {
+                "caps": [
+                    "CAP_PERFMON"
+                ]
+            }
+        },
+        {
+            "names": [
+                "clone",
+                "clone3",
+                "keyctl",
+                "mount",
+                "pivot_root",
+                "sethostname",
+                "setns",
+                "umount2",
+                "unshare"
+            ],
+            "action": "SCMP_ACT_ALLOW",
+            "args": [],
+            "comment": "",
+            "includes": {},
+            "excludes": {}
+        }
+    ]
 }


### PR DESCRIPTION
The profile carried the whole block the engine's default gates behind CAP_SYS_ADMIN, rather than the calls the rootless daemon actually makes. That left ptrace, process_vm_readv, process_vm_writev and pidfd_getfd open, which read and write another process's memory and take its open descriptors at the same uid, where nothing but the filter stands in the way. reboot, syslog and the whole new mount API were open too.

It had also drifted: fourteen calls the current default permits were missing, among them mseal, statmount and the *xattrat family, which a newer libc reaches for and would have found absent.

Regenerate from the current default and open clone, clone3, unshare, mount, umount2, pivot_root, setns, keyctl and sethostname. The last two came out of a run rather than a reading: the runtime creates a session keyring for each container and sets its hostname.

Checked against the rootless daemon, which starts, reports overlay2 and runs nested containers as root and as an unprivileged user.