### PR TITLE
feat(devcontainer)!: take the rootless engine and drop privileged

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -41,8 +41,6 @@ services:
       - projects:/home/ubuntu/projects
       # Public proxy CA, folded into the trust store
       - ${HOME}/.config/o3s/mitmproxy-ca.crt:/usr/local/share/ca-certificates/mitmproxy-ca.crt:ro
-      # Image and layer store of the rootless daemon
-      - rootless-docker:/home/ubuntu/.local/share/docker
     # Limit ressource usage
     deploy:
       resources:
@@ -57,10 +55,19 @@ services:
     # Point the default route at the gateway
     cap_add:
       - NET_ADMIN
-    # Admit the namespaces and syscalls the rootless daemon creates
+    # Capabilities the daemon leaves unused, one of them creating device nodes at will
+    cap_drop:
+      - MKNOD
+      - NET_RAW
+      - AUDIT_WRITE
+    # The device the userspace network stack builds its tap on
+    devices:
+      - /dev/net/tun
+    # The namespaces and mounts the daemon creates, over a procfs left open enough to mount
     security_opt:
       - apparmor=unconfined
       - seccomp=./seccomp.json
+      - systempaths=unconfined
     # Bring the cage up behind the gateway
     command: bash /home/ubuntu/o3s/.devcontainer/cage/start.sh
     # Its sole exit is the gateway
@@ -179,4 +186,3 @@ networks:
 volumes:
   features:
   projects:
-  rootless-docker:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
             "stateDir": "/home/ubuntu/features/codex",
             "version": "latest"
         },
-        "ghcr.io/hansehart/devcontainer-features/docker-in-docker:1": {
+        "ghcr.io/hansehart/devcontainer-features/docker-in-docker:2": {
             "daemonJson": "{\\\"dns\\\":[\\\"10.10.0.2\\\"]}",
             "version": "latest"
         // },


### PR DESCRIPTION
Blocked until docker-in-docker 2.0.0 publishes. Draft until then, since the pin does not resolve before that.

The feature declared privileged, which the CLI applies to the whole cage, so anyone in the docker group could start a privileged nested container and reach the host disk. Pinning the second major takes the rootless daemon instead, which runs as the remote user.

It asks for a few things in return. The daemon mounts namespaces and a procfs of its own, so the cage leaves its own procfs unmasked and keeps the profiles that admit those mounts. It builds its network on a tap device, which it can be given rather than allowed to create, so the capability that creates any device node goes and two the daemon never uses go with it. The store volume goes too, since it now sits under a name of its own rather than the remote user home and the feature declares it.

The cage ends up on eleven capabilities where a default container has fourteen, with no host devices beyond the tap, read-only cgroups, and no root daemon at all.