### PR TITLE
feat(devcontainer): confine the cage and share the nested daemon's socket

### DIFF
--- a/.devcontainer/apparmor.conf
+++ b/.devcontainer/apparmor.conf
@@ -1,13 +1,23 @@
-# The cage's confinement profile, which the host kernel holds and applies to every process
-# in it. The profile the runtime generates denies mount outright, which stops the rootless
-# engine before it starts, so mounts are permitted here and the file denials are kept.
+# NAME
+#        apparmor.conf — the cage's confinement profile
 #
-# initialize.sh loads it on the host, the only place a profile can be registered, and
-# compose names it under security_opt.
+# DESCRIPTION
+#        The rules the host kernel applies to every process in the cage, and to every
+#        container the nested engine starts within it. Derived from the profile the runtime
+#        generates, widened to the namespaces and mounts a rootless engine needs and
+#        narrowed to the kernel interfaces the cage has a use for.
 #
-# It mediates files, not mounts. Read it as narrowing what the cage can reach, not as
-# confining what it can mount.
+#        initialize.sh registers it with the host kernel, the one place a profile lives, and
+#        compose names it under the cage's security_opt.
+#
+#        Comments on the inherited rules are the runtime's own, kept as they stand so this
+#        file stays diffable against it.
+#
+# SEE ALSO
+#        apparmor.d(5), compose.yaml, initialize.sh
 
+# ABI 3.0 keeps unix sockets inside "network" and leaves user namespaces unmediated, both
+# of which the rootless engine relies on
 abi <abi/3.0>,
 
 #include <tunables/global>
@@ -22,8 +32,7 @@ profile o3s-cage flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
-  # The engine creates its namespaces and lays out every container's filesystem, so the
-  # mounts the generated profile denies are the ones it cannot run without.
+  # The namespaces the engine creates and the filesystems it lays out for each container
   mount,
   pivot_root,
 
@@ -37,20 +46,17 @@ profile o3s-cage flags=(attach_disconnected,mediate_deleted) {
   signal (send,receive) peer=o3s-cage,
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
-  # The runtime reopens its own descriptors through /proc/<pid>/fd, so the generated
-  # profile's blanket denial on every non-numeric name under /proc cannot be carried here.
-  # These name the directories it stands in for instead.
+  # The directories the runtime keeps read-only
   deny @{PROC}/bus/** w,
   deny @{PROC}/fs/** w,
   deny @{PROC}/irq/** w,
-  # deny /proc/sys except /proc/sys/k* and /proc/sys/net/*, the latter carrying the sysctls
-  # the engine sets on a container's interface.
+  # deny /proc/sys except /proc/sys/k* and the sysctls the engine sets per interface
   deny @{PROC}/sys/[^kn]** w,
   deny @{PROC}/sys/n[^e]** w,
   deny @{PROC}/sys/ne[^t]** w,
   deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
 
-  # The paths the runtime masks by default, which an unmasked procfs leaves in the open.
+  # The paths the runtime masks by default, left in the open by an unmasked procfs
   deny @{PROC}/acpi/** rwklx,
   deny @{PROC}/asound/** rwklx,
   deny @{PROC}/scsi/** rwklx,

--- a/.devcontainer/apparmor.conf
+++ b/.devcontainer/apparmor.conf
@@ -1,0 +1,78 @@
+# The cage's confinement profile, which the host kernel holds and applies to every process
+# in it. The profile the runtime generates denies mount outright, which stops the rootless
+# engine before it starts, so mounts are permitted here and the file denials are kept.
+#
+# initialize.sh loads it on the host, the only place a profile can be registered, and
+# compose names it under security_opt.
+#
+# It mediates files, not mounts. Read it as narrowing what the cage can reach, not as
+# confining what it can mount.
+
+abi <abi/3.0>,
+
+#include <tunables/global>
+
+profile o3s-cage flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  # Disallow AF_ALG (Linux kernel crypto API); see https://copy.fail/
+  deny network alg,
+  capability,
+  file,
+  umount,
+
+  # The engine creates its namespaces and lays out every container's filesystem, so the
+  # mounts the generated profile denies are the ones it cannot run without.
+  mount,
+  pivot_root,
+
+  # Host (privileged) processes may send signals to container processes.
+  signal (receive) peer=unconfined,
+  # runc may send signals to container processes (for "docker stop").
+  signal (receive) peer=runc,
+  # crun may send signals to container processes (for "docker stop" when used with crun OCI runtime).
+  signal (receive) peer=crun,
+  # Container processes may send signals amongst themselves.
+  signal (send,receive) peer=o3s-cage,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # The runtime reopens its own descriptors through /proc/<pid>/fd, so the generated
+  # profile's blanket denial on every non-numeric name under /proc cannot be carried here.
+  # These name the directories it stands in for instead.
+  deny @{PROC}/bus/** w,
+  deny @{PROC}/fs/** w,
+  deny @{PROC}/irq/** w,
+  # deny /proc/sys except /proc/sys/k* and /proc/sys/net/*, the latter carrying the sysctls
+  # the engine sets on a container's interface.
+  deny @{PROC}/sys/[^kn]** w,
+  deny @{PROC}/sys/n[^e]** w,
+  deny @{PROC}/sys/ne[^t]** w,
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+
+  # The paths the runtime masks by default, which an unmasked procfs leaves in the open.
+  deny @{PROC}/acpi/** rwklx,
+  deny @{PROC}/asound/** rwklx,
+  deny @{PROC}/scsi/** rwklx,
+  deny @{PROC}/interrupts rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny @{PROC}/keys rwklx,
+  deny @{PROC}/latency_stats rwklx,
+  deny @{PROC}/sched_debug rwklx,
+  deny @{PROC}/timer_list rwklx,
+  deny @{PROC}/timer_stats rwklx,
+  deny @{PROC}/sysrq-trigger rwklx,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/devices/virtual/powercap/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # allow processes within the container to trace each other,
+  # provided all other LSM and yama setting allow it.
+  ptrace (trace,tracedby,read,readby) peer=o3s-cage,
+}

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -41,6 +41,8 @@ services:
       - projects:/home/ubuntu/projects
       # Public proxy CA, folded into the trust store
       - ${HOME}/.config/o3s/mitmproxy-ca.crt:/usr/local/share/ca-certificates/mitmproxy-ca.crt:ro
+      # Directory a nested daemon shares its socket in, for the host to reach its containers
+      - ${HOME}/.${O3S_STACK}-docker-host:/run/docker-host
     # Limit ressource usage
     deploy:
       resources:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -42,7 +42,7 @@ services:
       # Public proxy CA, folded into the trust store
       - ${HOME}/.config/o3s/mitmproxy-ca.crt:/usr/local/share/ca-certificates/mitmproxy-ca.crt:ro
       # Directory a nested daemon shares its socket in, for the host to reach its containers
-      - ${HOME}/.${O3S_STACK}-docker-host:/run/docker-host
+      - ${HOME}/.o3s-docker-host:/run/docker-host
     # Limit ressource usage
     deploy:
       resources:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -65,7 +65,7 @@ services:
       - /dev/net/tun
     # The namespaces and mounts the daemon creates, over a procfs left open enough to mount
     security_opt:
-      - apparmor=unconfined
+      - apparmor=o3s-cage
       - seccomp=./seccomp.json
       - systempaths=unconfined
     # Bring the cage up behind the gateway

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -42,7 +42,7 @@ services:
       # Public proxy CA, folded into the trust store
       - ${HOME}/.config/o3s/mitmproxy-ca.crt:/usr/local/share/ca-certificates/mitmproxy-ca.crt:ro
       # Directory a nested daemon shares its socket in, for the host to reach its containers
-      - ${HOME}/.o3s-docker-host:/run/docker-host
+      - ${HOME}/.${COMPOSE_PROJECT_NAME}-docker-host:/run/docker-host
     # Limit ressource usage
     deploy:
       resources:

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -12,7 +12,7 @@
 #        Dev Containers extension, command "Dev Containers: Rebuild and Reopen in Container".
 #
 # SEE ALSO
-#        devcontainer.json, config.toml
+#        apparmor.conf, config.toml, devcontainer.json
 
 # Stack name
 name: o3s
@@ -65,7 +65,7 @@ services:
     # The device the userspace network stack builds its tap on
     devices:
       - /dev/net/tun
-    # The namespaces and mounts the daemon creates, over a procfs left open enough to mount
+    # Its own profile and syscall filter, over a procfs left open enough to mount
     security_opt:
       - apparmor=o3s-cage
       - seccomp=./seccomp.json

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -28,9 +28,6 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
-# The stack this cage runs as, named by the variable compose reads first
-STACK="${COMPOSE_PROJECT_NAME:-o3s}"
-
 # Load the cage's confinement profile where this host's kernel enforces AppArmor
 PROFILE=.devcontainer/apparmor.conf
 if [ -f "$PROFILE" ] && aa-enabled --quiet 2>/dev/null; then
@@ -58,7 +55,6 @@ MARKER="${MARKER:-o3s-$(openssl rand -hex 32)}"
   echo "O3S_MARKER=$MARKER"
   echo "O3S_UID=$(id -u)"
   echo "O3S_GID=$(id -g)"
-  echo "O3S_STACK=$STACK"
 } > "$ENV_FILE.new"
 mv "$ENV_FILE.new" "$ENV_FILE"
 

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -28,12 +28,8 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
-# The stack these compose files name, which the last of them decides
-STACK=o3s
-for f in $(grep -o '"compose[^"]*\.yaml"' .devcontainer/devcontainer.json | tr -d '"'); do
-  n="$(sed -n 's/^name:[[:space:]]*//p' ".devcontainer/$f" | head -1)"
-  [ -n "$n" ] && STACK="$n"
-done
+# The stack this cage runs as, which its own mounts are named for
+STACK="${O3S_STACK:-o3s}"
 
 # Load the cage's confinement profile where this host's kernel enforces AppArmor
 PROFILE=.devcontainer/apparmor.conf

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -28,6 +28,14 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
+# Load the cage's confinement profile where this host's kernel enforces AppArmor
+PROFILE=.devcontainer/apparmor.conf
+if [ -f "$PROFILE" ] && aa-enabled --quiet 2>/dev/null; then
+  log "locking down the cage's processes from the host kernel, which requires root"
+  sudo apparmor_parser -r -T -W "$PROFILE" 2>/dev/null \
+    || log "load this host's confinement profile: sudo apparmor_parser -r $PROFILE"
+fi
+
 # Seed the real-token file from its template
 [ -f "$SECRETS_DIR/secrets.env" ] \
   || install -m 600 .devcontainer/templates/secrets.env "$SECRETS_DIR/secrets.env"

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -28,8 +28,8 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
-# The stack this cage runs as, which its own mounts are named for
-STACK="${O3S_STACK:-o3s}"
+# The stack this cage runs as, named by the variable compose reads first
+STACK="${COMPOSE_PROJECT_NAME:-o3s}"
 
 # Load the cage's confinement profile where this host's kernel enforces AppArmor
 PROFILE=.devcontainer/apparmor.conf

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -21,11 +21,11 @@ CONFIG_FILE=.devcontainer/config.toml
 [ -f "$CONFIG_FILE" ]                   || cp .devcontainer/templates/config.toml "$CONFIG_FILE"
 [ -f .devcontainer/o3s.code-workspace ] || cp .devcontainer/templates/o3s.code-workspace .devcontainer/o3s.code-workspace
 
-# Where this host's secrets live
+# Hold this host's secrets in a directory only this account reads
 SECRETS_DIR="${O3S_SECRETS_DIR:-$HOME/.config/o3s}"
 install -d -m 700 "$SECRETS_DIR"
 
-# This host's egress-proxy CA
+# Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
 # Seed the real-token file from its template

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -5,10 +5,11 @@
 #
 # DESCRIPTION
 #        Seeds each editable config file from its template, creates this host's egress-proxy
-#        CA and secret slots, and regenerates the values compose reads at create time.
+#        CA and secret slots, registers the cage's confinement profile with this host's
+#        kernel, and regenerates the values compose reads at create time.
 #
 # SEE ALSO
-#        devcontainer.json, gen-ca.sh, post-start.sh
+#        apparmor.conf, devcontainer.json, gen-ca.sh, post-start.sh
 
 set -euo pipefail
 
@@ -16,6 +17,7 @@ log() { echo "[o3s] INFO: $*"; }
 
 ENV_FILE=.devcontainer/.env
 CONFIG_FILE=.devcontainer/config.toml
+PROFILE_FILE=.devcontainer/apparmor.conf
 
 # Seed each editable config file from its template if missing
 [ -f "$CONFIG_FILE" ]                   || cp .devcontainer/templates/config.toml "$CONFIG_FILE"
@@ -29,11 +31,10 @@ install -d -m 700 "$SECRETS_DIR"
 bash .devcontainer/proxy/gen-ca.sh
 
 # Load the cage's confinement profile where this host's kernel enforces AppArmor
-PROFILE=.devcontainer/apparmor.conf
-if [ -f "$PROFILE" ] && aa-enabled --quiet 2>/dev/null; then
-  log "locking down the cage's processes from the host kernel, which requires root"
-  sudo apparmor_parser -r -T -W "$PROFILE" 2>/dev/null \
-    || log "load this host's confinement profile: sudo apparmor_parser -r $PROFILE"
+if [ -f "$PROFILE_FILE" ] && aa-enabled --quiet 2>/dev/null; then
+  sudo apparmor_parser -r -T -W "$PROFILE_FILE" 2>/dev/null \
+    && log "loaded the cage's confinement profile" \
+    || log "load this host's confinement profile: sudo apparmor_parser -r $PROFILE_FILE"
 fi
 
 # Seed the real-token file from its template

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -28,6 +28,13 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
+# The stack these compose files name, which the last of them decides
+STACK=o3s
+for f in $(grep -o '"compose[^"]*\.yaml"' .devcontainer/devcontainer.json | tr -d '"'); do
+  n="$(sed -n 's/^name:[[:space:]]*//p' ".devcontainer/$f" | head -1)"
+  [ -n "$n" ] && STACK="$n"
+done
+
 # Load the cage's confinement profile where this host's kernel enforces AppArmor
 PROFILE=.devcontainer/apparmor.conf
 if [ -f "$PROFILE" ] && aa-enabled --quiet 2>/dev/null; then
@@ -55,6 +62,7 @@ MARKER="${MARKER:-o3s-$(openssl rand -hex 32)}"
   echo "O3S_MARKER=$MARKER"
   echo "O3S_UID=$(id -u)"
   echo "O3S_GID=$(id -g)"
+  echo "O3S_STACK=$STACK"
 } > "$ENV_FILE.new"
 mv "$ENV_FILE.new" "$ENV_FILE"
 


### PR DESCRIPTION
Two things the cage was missing, plus the comment pass that came with them.

### Confinement

`apparmor.conf` derives from docker-default and keeps what the nested rootless daemon needs — `mount`, `pivot_root`, its own namespaces — while closing the kernel interfaces the cage has no use for: `/proc/kcore`, `sched_debug`, `sysrq-trigger`, `/sys/firmware`, keys. `security_opt` moves from `apparmor=unconfined` to `apparmor=o3s-cage`, and `initialize.sh` loads the profile before the cage is created, where the host kernel enforces AppArmor, printing the command to run by hand where it cannot.

Note this makes the profile a start-time dependency: on a host where AppArmor is enabled but the profile failed to load, the cage will not start until `sudo apparmor_parser -r .devcontainer/apparmor.conf` has run.

### Socket bridge

The cage mounts `${HOME}/.${COMPOSE_PROJECT_NAME}-docker-host` at `/run/docker-host`. Where the docker-in-docker feature is installed, its daemon leaves a socket there and the host can open it, so nested dev containers are reachable from outside.

Compose offers its own resolved project name back to interpolation, so the directory follows whatever the project actually is — the `name:` of the last compose file, `COMPOSE_PROJECT_NAME`, or `-p`. Since the extension always passes `--project-name` explicitly, `o3s` and `o3s-dev` get their own directory by construction and neither can take over the other's socket.

This is the whole of what o3s knows about that feature: one mount. Everything else — the listener, the ownership, `DOCKER_HOST` — is the feature's, released as `2.1.0` in Hansehart/devcontainer-features#52. Hansehart/devcontainer-features#53 follows with `2.1.1`, which closes that directory to a single account; since this repo pins `docker-in-docker:2` at `latest`, it arrives without an o3s change.

Reaching the socket takes a context named once by hand, since nothing in the container can write the host's docker config:

```
docker context create o3s-dind --docker host=unix://$HOME/.o3s-docker-host/docker.sock
```

### Verification

- Profile loads and runs in enforce mode on WSL2 with `lsm=` reordered; nested containers work under it.
- `docker compose config` against the real files: `name: o3s` gives `~/.o3s-docker-host`, adding `compose.dev.yaml` gives `~/.o3s-dev-docker-host`, and `COMPOSE_PROJECT_NAME` and `-p` each override both.
- `bash -n` on `initialize.sh`.