### PR TITLE
feat(devcontainer): open this checkout to the cage under development

### DIFF
--- a/.devcontainer/compose.dev.yaml
+++ b/.devcontainer/compose.dev.yaml
@@ -30,6 +30,9 @@ services:
     pull_policy: build
     environment:
       GATEWAY_IP: *gateway_ip
+    volumes:
+      # For developing cage, this directory becomes writable
+      - ../:/home/ubuntu/o3s
     # Replace the inherited list, so resolv.conf holds this stack's gateway alone
     dns: !override
       - *gateway_ip


### PR DESCRIPTION
The daily stack mounts the repository read-only, which is right for it and wrong for the stack that builds its images from that same checkout — you cannot develop o3s inside a cage that cannot write to it.

Compose merges service volumes by their target, so naming the same path here replaces the inherited entry rather than adding a second one. The daily stack keeps `read_only: true`; only the dev overlay opens it.

This fits what the file already does for `dns` and the proxy's `command`: remap what the daily stack claims, and leave `compose.yaml` untouched.

### Verification

- `docker compose -f compose.yaml config` resolves the mount with `read_only: true`.
- `docker compose -f compose.yaml -f compose.dev.yaml config` resolves it writable, as a single entry.