### PR TITLE
fix(devcontainer): keep the cage's file capabilities on any host

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -67,6 +67,8 @@ services:
       - /dev/net/tun
     # Its own profile and syscall filter, over a procfs left open enough to mount
     security_opt:
+      # Let exec grant the file capabilities the daemon's id-mapping helpers hold
+      - no-new-privileges=false
       - apparmor=o3s-cage
       - seccomp=./seccomp.json
       - systempaths=unconfined


### PR DESCRIPTION
The nested rootless daemon maps its ids through `newuidmap` and `newgidmap`, which carry their privilege in file capabilities — the docker-in-docker feature restores `cap_setuid,cap_setgid+ep` on them at start for exactly that reason.

Under `no_new_privs` the kernel hands over none of it: `fs/exec.c:1593` marks the exec `LSM_UNSAFE_NO_NEW_PRIVS`, and `security/commoncap.c:950-960` then intersects the new permitted set with the old one, so the `setcap` grants nothing. Rootless `dockerd` dies at `newuidmap` with an error that names neither the flag nor the reason.

Nothing in the cage decides that. A host whose `daemon.json` sets `"no-new-privileges": true` applies it to every container it starts, including this one — which is a reasonable thing for a hardened workstation to do, and it makes o3s unusable there.

A container can opt out: `daemon_unix.go:200` seeds the container's setting from the daemon-wide config, and `parseSecurityOpt` (204-250) then lets the container's own `no-new-privileges=false` overwrite it.

This reads like a weakening but is not one — the cage already depends on those file capabilities to start at all, so the line states a requirement rather than removing a protection, and on a host with the default it changes nothing. The gateway and proxy keep `no-new-privileges:true`; only the cage needs this.

### Verification

`docker compose config` resolves the cage's `security_opt` to `no-new-privileges=false`, `apparmor=o3s-cage`, `seccomp=./seccomp.json`, `systempaths=unconfined`, with the gateway and proxy untouched.