### PR TITLE
fix(devcontainer): install the confinement profile once

### DIFF
--- a/.devcontainer/apparmor.conf
+++ b/.devcontainer/apparmor.conf
@@ -7,8 +7,8 @@
 #        generates, widened to the namespaces and mounts a rootless engine needs and
 #        narrowed to the kernel interfaces the cage has a use for.
 #
-#        initialize.sh registers it with the host kernel, the one place a profile lives, and
-#        compose names it under the cage's security_opt.
+#        initialize.sh installs it where the host kernel loads it at boot, the one place a
+#        profile lives, and compose names it under the cage's security_opt.
 #
 #        Comments on the inherited rules are the runtime's own, kept as they stand so this
 #        file stays diffable against it.

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -5,8 +5,8 @@
 #
 # DESCRIPTION
 #        Seeds each editable config file from its template, creates this host's egress-proxy
-#        CA and secret slots, registers the cage's confinement profile with this host's
-#        kernel, and regenerates the values compose reads at create time.
+#        CA and secret slots, installs the cage's confinement profile where this host loads
+#        it at boot, and regenerates the values compose reads at create time.
 #
 # SEE ALSO
 #        apparmor.conf, devcontainer.json, gen-ca.sh, post-start.sh
@@ -18,6 +18,7 @@ log() { echo "[o3s] INFO: $*"; }
 ENV_FILE=.devcontainer/.env
 CONFIG_FILE=.devcontainer/config.toml
 PROFILE_FILE=.devcontainer/apparmor.conf
+INSTALLED_PROFILE=/etc/apparmor.d/o3s-cage
 
 # Seed each editable config file from its template if missing
 [ -f "$CONFIG_FILE" ]                   || cp .devcontainer/templates/config.toml "$CONFIG_FILE"
@@ -30,11 +31,19 @@ install -d -m 700 "$SECRETS_DIR"
 # Generate this host's egress-proxy CA
 bash .devcontainer/proxy/gen-ca.sh
 
-# Load the cage's confinement profile where this host's kernel enforces AppArmor
+# Install the cage's confinement profile where this host's kernel enforces AppArmor
 if [ -f "$PROFILE_FILE" ] && aa-enabled --quiet 2>/dev/null; then
-  sudo apparmor_parser -r -T -W "$PROFILE_FILE" 2>/dev/null \
-    && log "loaded the cage's confinement profile" \
-    || log "load this host's confinement profile: sudo apparmor_parser -r $PROFILE_FILE"
+  # Leave the kernel alone where it already holds the profile this host installed
+  if cmp -s "$PROFILE_FILE" "$INSTALLED_PROFILE"; then
+    log "the cage's confinement profile is loaded"
+  # Load it, then leave it where this host loads it at every boot, asking for privilege once
+  elif sudo sh -c 'apparmor_parser -r -T "$1" && install -m 644 "$1" "$2"' \
+        _ "$PROFILE_FILE" "$INSTALLED_PROFILE"; then
+    log "installed the cage's confinement profile"
+  # Leave the step to whoever holds the privilege this host withheld
+  else
+    log "install this host's confinement profile: sudo apparmor_parser -r $PROFILE_FILE && sudo install -m 644 $PROFILE_FILE $INSTALLED_PROFILE"
+  fi
 fi
 
 # Seed the real-token file from its template


### PR DESCRIPTION
initializeCommand is the only host-side lifecycle hook, and the CLI runs it on every open, reload and rebuild. Loading the profile there asked for a sudo password every single time.

Install it under /etc/apparmor.d instead, where the host loads it at boot, and do nothing while the kernel holds it and the installed copy still matches. That copy is the record of what is loaded, so the step needs no cache of its own.