### PR TITLE
feat(devcontainer): add vim and less to the cage base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       git \
       iproute2 \
+      less \
       openssh-client \
       ripgrep \
+      vim \
   && rm -rf /var/lib/apt/lists/*
 
 # TOML/YAML parser


### PR DESCRIPTION
  ## Summary

 - Added `vim` and `less` to the package list in `images/base/Dockerfile`, which builds the `cage` container's base image.

  ## Why

The `cage` container is the environment where development actually happens, but the base image only shipped minimal tooling so far (`curl`, `git`, `ripgrep`,   etc.) — no pager and no terminal editor. Both are common building blocks for a shell environment.