### PR TITLE
fix(initialize): ask the kernel whether the cage's profile is loaded

### DIFF
--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -24,9 +24,11 @@ INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
 # Read the policy this host's kernel lays out, where every load names the profile afresh
 profile_is_loaded() {
   local mnt
+  # Walk each mount this host reports
   while read -r mnt; do
-    # Answer from whichever mount carries the policy, as not all of them do
+    # Answer from the mount that carries the policy
     compgen -G "$mnt/apparmor/policy/profiles/$PROFILE_NAME.*" > /dev/null && return 0
+  # Draw them from the mount table the kernel keeps
   done < <(awk '$3 == "securityfs" { print $2 }' /proc/mounts)
   return 1
 }

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -25,6 +25,7 @@ INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
 profile_is_loaded() {
   local mnt
   while read -r mnt; do
+    # Answer from whichever mount carries the policy, as not all of them do
     compgen -G "$mnt/apparmor/policy/profiles/$PROFILE_NAME.*" > /dev/null && return 0
   done < <(awk '$3 == "securityfs" { print $2 }' /proc/mounts)
   return 1

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -18,7 +18,19 @@ log() { echo "[o3s] INFO: $*"; }
 ENV_FILE=.devcontainer/.env
 CONFIG_FILE=.devcontainer/config.toml
 PROFILE_FILE=.devcontainer/apparmor.conf
-INSTALLED_PROFILE=/etc/apparmor.d/o3s-cage
+PROFILE_NAME=o3s-cage
+INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
+LOADED_PROFILES=/sys/kernel/security/apparmor/policy/profiles
+
+profile_is_loaded() {
+  # Read the policy this host's kernel lays out, where every load names the profile afresh
+  if [ -d "$LOADED_PROFILES" ]; then
+    compgen -G "$LOADED_PROFILES/$PROFILE_NAME.*" > /dev/null
+  # Take the installed file for an answer where this host lays no policy out
+  else
+    cmp -s "$PROFILE_FILE" "$INSTALLED_PROFILE"
+  fi
+}
 
 # Seed each editable config file from its template if missing
 [ -f "$CONFIG_FILE" ]                   || cp .devcontainer/templates/config.toml "$CONFIG_FILE"
@@ -34,15 +46,15 @@ bash .devcontainer/proxy/gen-ca.sh
 # Install the cage's confinement profile where this host's kernel enforces AppArmor
 if [ -f "$PROFILE_FILE" ] && aa-enabled --quiet 2>/dev/null; then
   # Leave the kernel alone where it already holds the profile this host installed
-  if cmp -s "$PROFILE_FILE" "$INSTALLED_PROFILE"; then
+  if profile_is_loaded && cmp -s "$PROFILE_FILE" "$INSTALLED_PROFILE"; then
     log "the cage's confinement profile is loaded"
   # Load it, then leave it where this host loads it at every boot, asking for privilege once
   elif sudo sh -c 'apparmor_parser -r -T "$1" && install -m 644 "$1" "$2"' \
         _ "$PROFILE_FILE" "$INSTALLED_PROFILE"; then
-    log "installed the cage's confinement profile"
+    log "loaded the cage's confinement profile"
   # Leave the step to whoever holds the privilege this host withheld
   else
-    log "install this host's confinement profile: sudo apparmor_parser -r $PROFILE_FILE && sudo install -m 644 $PROFILE_FILE $INSTALLED_PROFILE"
+    log "load this host's confinement profile: sudo apparmor_parser -r $PROFILE_FILE && sudo install -m 644 $PROFILE_FILE $INSTALLED_PROFILE"
   fi
 fi
 

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -22,14 +22,9 @@ PROFILE_NAME=o3s-cage
 INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
 LOADED_PROFILES=/sys/kernel/security/apparmor/policy/profiles
 
+# Read the policy this host's kernel lays out, where every load names the profile afresh
 profile_is_loaded() {
-  # Read the policy this host's kernel lays out, where every load names the profile afresh
-  if [ -d "$LOADED_PROFILES" ]; then
-    compgen -G "$LOADED_PROFILES/$PROFILE_NAME.*" > /dev/null
-  # Take the installed file for an answer where this host lays no policy out
-  else
-    cmp -s "$PROFILE_FILE" "$INSTALLED_PROFILE"
-  fi
+  compgen -G "$LOADED_PROFILES/$PROFILE_NAME.*" > /dev/null
 }
 
 # Seed each editable config file from its template if missing

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -23,9 +23,11 @@ INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
 
 # Read the policy this host's kernel lays out, where every load names the profile afresh
 profile_is_loaded() {
-  local securityfs
-  securityfs=$(awk '$3 == "securityfs" { print $2; exit }' /proc/mounts)
-  compgen -G "$securityfs/apparmor/policy/profiles/$PROFILE_NAME.*" > /dev/null
+  local mnt
+  while read -r mnt; do
+    compgen -G "$mnt/apparmor/policy/profiles/$PROFILE_NAME.*" > /dev/null && return 0
+  done < <(awk '$3 == "securityfs" { print $2 }' /proc/mounts)
+  return 1
 }
 
 # Seed each editable config file from its template if missing

--- a/.devcontainer/lifecycle/initialize.sh
+++ b/.devcontainer/lifecycle/initialize.sh
@@ -20,11 +20,12 @@ CONFIG_FILE=.devcontainer/config.toml
 PROFILE_FILE=.devcontainer/apparmor.conf
 PROFILE_NAME=o3s-cage
 INSTALLED_PROFILE=/etc/apparmor.d/$PROFILE_NAME
-LOADED_PROFILES=/sys/kernel/security/apparmor/policy/profiles
 
 # Read the policy this host's kernel lays out, where every load names the profile afresh
 profile_is_loaded() {
-  compgen -G "$LOADED_PROFILES/$PROFILE_NAME.*" > /dev/null
+  local securityfs
+  securityfs=$(awk '$3 == "securityfs" { print $2; exit }' /proc/mounts)
+  compgen -G "$securityfs/apparmor/policy/profiles/$PROFILE_NAME.*" > /dev/null
 }
 
 # Seed each editable config file from its template if missing


### PR DESCRIPTION
The profile lives in kernel memory alone, so comparing files on disk reported it loaded on a host whose kernel had dropped it, and the cage failed to start. initialize.sh now reads the loaded policy and reloads the profile when it is gone.