### PR TITLE
test(repo): cover the confinement a restart drops

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test the stack
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ubuntu:
+    # pin the release, so the kernel under the suite keeps enforcing AppArmor
+    runs-on: ubuntu-24.04
+    steps:
+      # check out the repo so the suite drives this branch's lifecycle and compose files
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # require the confinement the suite reads back
+      - name: Require AppArmor
+        run: aa-enabled
+
+      # install the CLI this host's editor raises the stack with
+      - name: Install the dev container CLI
+        run: npm install -g @devcontainers/cli
+
+      # hold the test dependencies apart from the interpreter this host manages
+      - name: Install the test dependencies
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet pytest pytest-testinfra
+
+      # run the suite against the stack this host raises
+      - name: Run the suite
+        run: .venv/bin/pytest test -v

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .devcontainer/o3s.code-workspace
 *.crt
 *.key
+.venv/
+.pytest_cache/
+__pycache__/

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,55 @@
+"""Raise o3s the way this host's editor raises it and hand the running cage to a test.
+
+This suite restarts the o3s this host already runs, and leaves it standing at the end, since the
+host it runs on is discarded with the job.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import testinfra
+
+REPO = Path(__file__).resolve().parents[1]
+PROFILE_FILE = REPO / ".devcontainer/apparmor.conf"
+PROFILE_NAME = "o3s-cage"
+POLICY = Path("/sys/kernel/security/apparmor/policy/profiles")
+
+
+def devcontainer_up():
+    """Raise the stack, and report what the CLI says it raised."""
+    raising = subprocess.run(
+        ["devcontainer", "up", "--workspace-folder", REPO],
+        capture_output=True,
+        text=True,
+    )
+    # fail with the refusal the CLI reports
+    assert raising.returncode == 0, raising.stdout or raising.stderr
+    return json.loads(raising.stdout)
+
+
+def cage(container_id):
+    """Address the container the stack runs the cage in."""
+    return testinfra.get_host(f"docker://{container_id}")
+
+
+def profile_is_loaded():
+    """Read the policy this host's kernel lays out, where every load names the profile afresh."""
+    return any(POLICY.glob(f"{PROFILE_NAME}.*"))
+
+
+@pytest.fixture
+def a_host_that_has_run_o3s():
+    """Leave this host holding the installed profile, as a restart that empties the kernel does."""
+    raised = devcontainer_up()
+
+    # read a loaded profile first, so the reading below carries weight
+    assert profile_is_loaded()
+
+    subprocess.run(["docker", "rm", "-f", raised["containerId"]], check=True)
+    subprocess.run(["sudo", "apparmor_parser", "-R", PROFILE_FILE], check=True)
+
+    # hold the arranged state to what it claims, so a test reads a kernel that lost the profile
+    assert not profile_is_loaded()
+    assert Path("/etc/apparmor.d", PROFILE_NAME).is_file()

--- a/test/test_confinement.py
+++ b/test/test_confinement.py
@@ -1,0 +1,17 @@
+"""Cover the confinement the cage holds on a host whose kernel has been emptied of the profile.
+
+The stack asks for the profile by name at start, and the kernel answers from the policy it holds.
+A host that comes back holding the installed file alone is therefore the state the cage must still
+start from.
+"""
+
+from conftest import cage, devcontainer_up
+
+
+def test_the_cage_is_confined_after_the_kernel_loses_the_profile(a_host_that_has_run_o3s):
+    """A host holding the installed profile alone raises a cage the kernel confines."""
+    raised = devcontainer_up()
+
+    confinement = cage(raised["containerId"]).file("/proc/self/attr/current")
+
+    assert confinement.content_string.strip() == "o3s-cage (enforce)"


### PR DESCRIPTION
Seeds a CI pipeline with one end-to-end test. It raises the stack through `devcontainer up`, empties the kernel of the cage's profile while leaving the installed file in place, and asserts the cage comes back reporting `o3s-cage (enforce)`.